### PR TITLE
feat: ToMap Method

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -366,6 +366,44 @@ func TestMemCache_DelExpired(t *testing.T) {
 	}
 }
 
+func TestMemCache_ToMap(t *testing.T) {
+	type args struct {
+		sleep time.Duration
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{
+		{name: "base", args: args{sleep: 0}, want: map[string]interface{}{
+			"int":     1,
+			"int32":   int32(1),
+			"int64":   int64(1),
+			"string":  "a",
+			"float64": 1.1,
+			"float32": float32(1.1),
+			"ex":      1,
+		}},
+		{name: "expired", args: args{sleep: 1 * time.Second}, want: map[string]interface{}{
+			"int":     1,
+			"int32":   int32(1),
+			"int64":   int64(1),
+			"string":  "a",
+			"float64": 1.1,
+			"float32": float32(1.1),
+		}},
+	}
+	c := mockCache()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			time.Sleep(tt.args.sleep)
+			if got := c.ToMap(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMemCache_Finalize(t *testing.T) {
 	tests := []struct {
 		name string

--- a/shard.go
+++ b/shard.go
@@ -105,3 +105,14 @@ func (c *memCacheShard) checkExpire() {
 		c.delExpired(k)
 	}
 }
+
+func (c *memCacheShard) saveToMap(target map[string]interface{}) {
+	c.lock.RLock()
+	for k, item := range c.hashmap {
+		if item.Expired() {
+			continue
+		}
+		target[k] = item.v
+	}
+	c.lock.RUnlock()
+}


### PR DESCRIPTION
New method `ToMap() map[string]interface{}`.
ToMap converts the current cache into a map with string keys and interface{} values.

Example:
```golang
	c.Set("a", 1)
	c.Set("b", "uu")
	c.ToMap() // return {"a":1,"b":"uu"}

	// when 
	c.Expire("a", 1*time.Second)
        time.Sleep(1*time.Second)
	c.ToMap() // return {"b":"uu"}
```
How the merging process works:
	1.Create a result map: The method starts by creating an empty map, result, using make(map[string]interface{}). This map will hold the final combined data from all the shards.
	2.Iterate over shards: Using a for loop, the method iterates over the shards slice stored in the memCache struct. Each shard is expected to hold part of the data.
	3.Call saveToMap: For each shard, it calls the saveToMap(result) method. This function adds the data from the shard into the result map by copying each key-value pair.
	4.Return the result: After all shards have been processed, the method returns the result map, which now contains all the combined data from the shards.